### PR TITLE
Create Home Page Page Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Clone Rep and run tests locally
+# Clone Repo and run tests locally
 ```
 git clone https://github.com/kel-o/calendly-watir.git
 cucumber features/signup_steps.feature

--- a/features/oauth_signup_steps.feature
+++ b/features/oauth_signup_steps.feature
@@ -1,0 +1,18 @@
+Feature: Calendly Signup flow with oauth email
+    As a non-calendly user with an oauth domain email
+    I want to sign up for Calendly 
+    And have the option to register using oauth
+
+Scenario Outline: Signing up from Landing Page with oauth email
+    Given I am a <domain type> user
+    When I am on the LandingPage 
+    And I enter my email address into the sign up text box 
+    When I submit email 
+    Then I am redirected to the <page>
+    Given the current page is the <page>
+    Then I can <action>
+    And I will be directed to the <redirect_page>
+    Scenarios:
+      | domain type         | page                 | action                             | redirect_page            |    
+      | calendly.com        | choose auth page     | click google auth                  | google oauth page        |       
+      | outlook.com         | chooe auth page      | click outlook auth                 | outlook oauth page       |

--- a/features/pages/home_page.rb
+++ b/features/pages/home_page.rb
@@ -1,0 +1,130 @@
+class HomePage
+    include PageObject 
+
+    def initialize(browser)
+        @browser = browser
+        @HOST_NAME = 'bravo-qa.calendly.com'
+    end 
+
+    def visit
+        @browser.goto "#{@HOST_NAME}"
+    end 
+
+    # Header Elements
+    #header menu items
+    def header(option)
+        list = ['Home', 'Availability', 'Integrations', 'Help', 'Account']
+        browser.element(:xpath => "//a[contains( text(), #{list[option]})]")
+    end
+        
+    #account dropdown items
+    def header_account_dropdown_options(option)
+        menu_list = ['Account Settings', 'Billing', 'Calendar Connections', 'Admin Management', 
+                'Organzation Settings', 'Share Your Link', 'Apps', 'Logout']
+        browser.element(:xpath => "//div[contains( text(), #{menu_list[option]})]")
+    end 
+    
+    # home bar component (top-level)
+    def home_bar_data_component
+        browser.div('data-component':'home-bar')
+    end
+
+    # home bar elements
+    def home_bar_element(option)
+        items = ['My Calendly', 'Create', 'Event Types', 'Scheduled Events', 'Scheduled Workflows']
+
+        begin 
+            browser.div('data-component':'home-bar').div(text: items[option])
+        rescue StandardError => e
+            "selector does not exist"
+        else 
+            browser.div('data-component':'home-bar').span(text:  items[option])
+        end
+        # browser.div('data-component':'home-bar').span(text: 'My Calendly')
+        # browser.div('data-component':'home-bar').div(text: 'Create')
+        # browser.div('data-component':'home-bar').div(text: 'Event Types')
+        # browser.div('data-component':'home-bar').div(text: 'Scheduled Events')
+        # browser.div('data-component':'home-bar').div(text: 'Scheduled Workflows')
+    end 
+
+    #################################
+    #Home content elements
+    #Home content data component (top-level)
+    def home_content
+        browser.div('data-component':'home-content')
+    end
+
+    #Top row
+    def home_content_filter
+        browser.div('data-component':'home-content').text_field(placeholder: 'Filter')
+    end   
+
+    def home_content_filter_clear_button
+    browser.div('data-component':'home-content').span(class: 'icon-delete')
+    end
+
+    def home_content_name_icon
+        browser.div('data-component':'home-content').div(text: 'K')
+    end
+
+    def home_content_account_owner_name
+        browser.div('data-component':'home-content').div(text: "#{org_owner}")
+    end 
+
+    def home_content_scheduling_page_link
+        browser.div('data-component':'home-content').a(text: 'bravo-qa.calendly.com/keltest')
+    end 
+
+    def home_content_new_event_type_button
+        browser.div('data-component':'home-content').element(:xpath => "//div[contains( text(), 'New Event Type')]")
+    end         
+
+    def home_content_share_landing_page_button
+        browser.div('data-component':'home-content').button('aria-label': 'Landing page share options')
+    end 
+
+    def home_content_share_landing_page_options(option)
+        list = ['Copy Link', 'Add to Website']
+        browser.div('data-component':'home-content').div(text: list[option])
+    end 
+
+    #Personal Event Types section elements
+    def event_type_select_box(index)
+        browser.div('data-component':'home-content').div(class: 'is-left', :index => index)
+    end
+
+    def event_type_settings_button
+        browser.div('data-component':'home-content').button('aria-label': "#{name} settings")
+    end 
+
+    def event_type_settings_options(option)
+        items = ['Edit', 'Add Internal Note', 'Clone', 'Save to Template', 'Delete', "On/Off"]
+        browser.div('data-component':'home-content').div(text: items[option])
+    end 
+
+    def event_type_name(name)
+        browser.div('data-component':'home-content').h2(text: name)
+    end 
+
+    def view_booking_page_link(index)
+        browser.div('data-component':'home-content').a(text: 'View booking page', :index => index )
+    end 
+
+    def copy_event_type_link_button(index)
+        browser.div('data-component':'home-content').button(text: 'Copy link', :index => index )
+    end 
+
+    def share_event_type_button(index)
+        browser.div('data-component':'home-content').div(text: 'Share', :index => index )
+    end
+
+
+    #Shared Event Types section
+    def shared_event_types_title
+        browser.div('data-component':'home-content').span(text: 'Shared event types')
+    end
+
+    def shared_event_types_content_blank_state
+        browser.div('data-component':'home-content').h3(text: "You don't have any shared event types yet.")
+    end
+end 

--- a/features/pages/home_page.rb
+++ b/features/pages/home_page.rb
@@ -12,33 +12,34 @@ class HomePage
 
     # Header Elements
     #header menu items
-    def header(option)
+    def header_menu(option)
         list = ['Home', 'Availability', 'Integrations', 'Help', 'Account']
         browser.element(:xpath => "//a[contains( text(), #{list[option]})]")
     end
         
     #account dropdown items
-    def header_account_dropdown_options(option)
-        menu_list = ['Account Settings', 'Billing', 'Calendar Connections', 'Admin Management', 
+    def header_menu_account_dropdown_options(option)
+        list = ['Account Settings', 'Billing', 'Calendar Connections', 'Admin Management', 
                 'Organzation Settings', 'Share Your Link', 'Apps', 'Logout']
-        browser.element(:xpath => "//div[contains( text(), #{menu_list[option]})]")
+        browser.element(:xpath => "//div[contains( text(), #{list[option]})]")
     end 
     
     # home bar component (top-level)
-    def home_bar_data_component
-        browser.div('data-component':'home-bar')
+    def home_bar_data_component 
+        browser.div('data-component': 'home-bar')
     end
 
     # home bar elements
+    #DRY way of selecting elements in the home bar component section - not very readable - subject to change
     def home_bar_element(option)
         items = ['My Calendly', 'Create', 'Event Types', 'Scheduled Events', 'Scheduled Workflows']
 
         begin 
-            browser.div('data-component':'home-bar').div(text: items[option])
+            browser.div('data-component': 'home-bar').div(text: items[option])
         rescue StandardError => e
             "selector does not exist"
         else 
-            browser.div('data-component':'home-bar').span(text:  items[option])
+            browser.div('data-component': 'home-bar').span(text: items[option])
         end
         # browser.div('data-component':'home-bar').span(text: 'My Calendly')
         # browser.div('data-component':'home-bar').div(text: 'Create')
@@ -51,80 +52,79 @@ class HomePage
     #Home content elements
     #Home content data component (top-level)
     def home_content
-        browser.div('data-component':'home-content')
+        browser.div('data-component': 'home-content')
     end
 
     #Top row
     def home_content_filter
-        browser.div('data-component':'home-content').text_field(placeholder: 'Filter')
+        browser.div('data-component': 'home-content').text_field(placeholder: 'Filter')
     end   
 
     def home_content_filter_clear_button
-    browser.div('data-component':'home-content').span(class: 'icon-delete')
+        browser.div('data-component': 'home-content').span(class: 'icon-delete')
     end
 
     def home_content_name_icon
-        browser.div('data-component':'home-content').div(text: 'K')
+        browser.div('data-component': 'home-content').div(text: 'K')
     end
 
     def home_content_account_owner_name
-        browser.div('data-component':'home-content').div(text: "#{org_owner}")
+        browser.div('data-component': 'home-content').div(text: "#{org_owner}")
     end 
 
     def home_content_scheduling_page_link
-        browser.div('data-component':'home-content').a(text: 'bravo-qa.calendly.com/keltest')
+        browser.div('data-component': 'home-content').a(text: 'bravo-qa.calendly.com/keltest')
     end 
 
     def home_content_new_event_type_button
-        browser.div('data-component':'home-content').element(:xpath => "//div[contains( text(), 'New Event Type')]")
+        browser.div('data-component': 'home-content').element(:xpath => "//div[contains( text(), 'New Event Type')]")
     end         
 
     def home_content_share_landing_page_button
-        browser.div('data-component':'home-content').button('aria-label': 'Landing page share options')
+        browser.div('data-component': 'home-content').button('aria-label': 'Landing page share options')
     end 
 
     def home_content_share_landing_page_options(option)
         list = ['Copy Link', 'Add to Website']
-        browser.div('data-component':'home-content').div(text: list[option])
+        browser.div('data-component': 'home-content').div(text: list[option])
     end 
 
     #Personal Event Types section elements
     def event_type_select_box(index)
-        browser.div('data-component':'home-content').div(class: 'is-left', :index => index)
+        browser.div('data-component': 'home-content').div(class: 'is-left', :index => index)
     end
 
     def event_type_settings_button
-        browser.div('data-component':'home-content').button('aria-label': "#{name} settings")
+        browser.div('data-component': 'home-content').button('aria-label': "#{name} settings")
     end 
 
     def event_type_settings_options(option)
         items = ['Edit', 'Add Internal Note', 'Clone', 'Save to Template', 'Delete', "On/Off"]
-        browser.div('data-component':'home-content').div(text: items[option])
+        browser.div('data-component': 'home-content').div(text: items[option])
     end 
 
-    def event_type_name(name)
-        browser.div('data-component':'home-content').h2(text: name)
+    def event_type_name(name) 'home-content').h2(text: name)
     end 
 
     def view_booking_page_link(index)
-        browser.div('data-component':'home-content').a(text: 'View booking page', :index => index )
+        browser.div('data-component': 'home-content').a(text: 'View booking page', :index => index )
     end 
 
     def copy_event_type_link_button(index)
-        browser.div('data-component':'home-content').button(text: 'Copy link', :index => index )
+        browser.div('data-component': 'home-content').button(text: 'Copy link', :index => index )
     end 
 
     def share_event_type_button(index)
-        browser.div('data-component':'home-content').div(text: 'Share', :index => index )
+        browser.div('data-component': 'home-content').div(text: 'Share', :index => index )
     end
 
 
     #Shared Event Types section
     def shared_event_types_title
-        browser.div('data-component':'home-content').span(text: 'Shared event types')
+        browser.div('data-component': 'home-content').span(text: 'Shared event types')
     end
 
     def shared_event_types_content_blank_state
-        browser.div('data-component':'home-content').h3(text: "You don't have any shared event types yet.")
+        browser.div('data-component': 'home-content').h3(text: "You don't have any shared event types yet.")
     end
 end 

--- a/features/pages/landing-page.rb
+++ b/features/pages/landing-page.rb
@@ -3,7 +3,7 @@ class LandingPage
     
     def initialize(browser)
         @browser = browser
-        @HOST_NAME = ''
+        @HOST_NAME = 'bravo-qa.calendly.com'
         # @my_page_object = MyPageObject.new(@browser)
     end 
 
@@ -11,10 +11,10 @@ class LandingPage
         @browser.goto "#{@HOST_NAME}"
     end 
 
+    #landing page, signup elements
     def email_textbox
         @browser.text_field(name: 'email', :index => 1 )
     end 
-    
     
     def enter_email_address(email)
         @browser.text_field(name: 'email', :index => 1 ).set email
@@ -23,13 +23,38 @@ class LandingPage
     def submit_email
         @browser.button(type: 'submit', :index => 1).click 
     end 
+    ####################
 
-    # in signup_steps.rb, we check for the existence of this element to verify the current page
-    def auth_page_element
-        @browser.span(class: 'icon-google').wait_until(&:present?)
+
+    #login page elements
+    def login_button
+        @browser.element(text: 'Log In' )
     end 
 
-     # in signup_steps.rb, we check for the existence of this elemtn to verify the current page
+    def login_email_textbox
+        @browser.text_field(placeholder: 'Enter your email')
+    end 
+    ####################
+
+    # sign up page elements
+    # in signup_steps.rb, we check for the existence of this element to verify the current page
+    def choose_auth_page_google
+        @browser.element(text: 'Sign up with Google').wait_until(&:present?)
+    end 
+
+    def click_google_auth 
+        @browser.element(text: 'Sign up with Google').wait_until(&:present?).click
+    end 
+
+    def choose_auth_page_outlook 
+        @browser.element(text: 'Sign up with Outlook.com').wait_until(&:present?)
+    end 
+
+    def click_outlook_auth
+        @browser.element(text: 'Sign up with Outlook.com').wait_until(&:present?).click
+    end 
+
+     # in signup_steps.rb, we check for the existence of this element to verify the current page
     def signup_page_element
         @browser.button(value: 'Continue').wait_until(&:present?)
     end
@@ -37,6 +62,7 @@ class LandingPage
     def create_password_account_button 
         @browser.button(text: 'Click here').click()
     end 
+    ######################
 
   
     def set_name_text_field(name) 

--- a/features/pages/landing-page.rb
+++ b/features/pages/landing-page.rb
@@ -13,15 +13,15 @@ class LandingPage
 
     #landing page, signup elements
     def email_textbox
-        @browser.text_field(name: 'email', :index => 1 )
+        @browser.div('data-testid': 'email-input').text_field
     end 
     
     def enter_email_address(email)
-        @browser.text_field(name: 'email', :index => 1 ).set email
+        email_textbox.set email
     end 
 
     def submit_email
-        @browser.button(type: 'submit', :index => 1).click 
+        @browser.button('data-testid':'regular-button').click 
     end 
     ####################
 

--- a/features/signup_steps.feature
+++ b/features/signup_steps.feature
@@ -14,12 +14,11 @@ Scenario Outline: Signing up from Landing Page with or without oauth email
     When I set name text field 
     When I set the password text field
     And I click submit 
-    Then I will be directed to invitation confirmation screen
+    Then I will be directed to the <redirect_page>
     Scenarios:
-      | domain type         | page                 | action                             |      
-      | calendly.com        | choose auth page     | click password auth                | 
-      | notcalendly.com     | sign up page         | verify I am on the sign up page    | 
-
+      | domain type         | page                 | action                             | redirect_page                     |
+      | calendly.com        | choose auth page     | click password auth                | invitation confirmation screen    |
+      | notcalendly.com     | sign up page         | verify I am on the sign up page    | invitation confirmation screen    |
 
 
 

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -19,14 +19,14 @@ When(/^I am on the (.+)$/) do |page_name|
  end 
  And(/^I enter my email address into the sign up text box$/) do
      @landing_page.enter_email_address(@email_address)
- end 
+ end   
  When(/^I submit email$/) do
      @landing_page.submit_email 
  end 
  Then(/^I am redirected to the (.+)$/) do |page| 
     case page
     when 'choose auth page'
-        expect(@landing_page.auth_page_element).to exist 
+        expect(@landing_page.choose_auth_page_google).to exist 
     when 'sign up page'
         expect(@landing_page.signup_page_element).to exist
     end
@@ -38,6 +38,10 @@ end
     case action
     when 'click password auth'
         @landing_page.create_password_account_button 
+    when 'click google auth'
+        @landing_page.choose_auth_page_google.click
+    when 'click outlook auth'
+        @landing_page.choose_auth_page_outlook.click
     when 'verify I am on the sign up page'
         expect(@landing_page.signup_page_element).to exist
     end 
@@ -52,7 +56,14 @@ end
 And(/^I click submit$/) do 
     @landing_page.submit_signup 
 end
-Then(/^I will be directed to invitation confirmation screen$/) do
-    expect(@landing_page.invitation_sent_text).to eq('Before continuing, we need to verify your email address. Please check your inbox for a confirmation link.')
+Then(/^I will be directed to the (.+)$/) do |redirect_page|
+    case redirect_page
+    when 'google oauth page'
+        expect(@landing_page.browser.url).to include('accounts.google')
+    when 'outlook oauth page'
+        expect(@landing_page.browser.url).to include('login.microsoftonline')
+    when 'invitation confirmation screen'
+        expect(@landing_page.invitation_sent_text).to eq('Before continuing, we need to verify your email address. Please check your inbox for a confirmation link.')
+    end 
 end 
 

--- a/tests/test_landing_page.rb
+++ b/tests/test_landing_page.rb
@@ -5,10 +5,10 @@ browser = Watir::Browser.new :chrome
 browser.goto 'bravo-qa.calendly.com'
 binding.pry
 
-browser.text_field(name: 'email', :index => 1 ).set 'kel.okekpe+watir111@calendly.com'
+# browser.text_field(name: 'email', :index => 1 ).set 'kel.okekpe+watir111@calendly.com'
 
-browser.button(type: 'submit', :index => 1).click
-binding.pry
+# browser.button(type: 'submit', :index => 1).click
+# binding.pry
 # browser.p(:index => 0).text
 # browser.button(value: 'Click here').click
 # binding.pry
@@ -17,3 +17,81 @@ binding.pry
 # browser.button(value: 'Continue').click
 
 # expect(browser.element(class: 'pbl').text).to eq("Before continuing, we need to verify your email address. Please check your inbox for a confirmation link.")
+
+#header menu items
+# browser.element(:xpath => "//a[contains( text(), 'Home')]")
+# browser.element(:xpath => "//a[contains( text(), 'Availability')]")
+# browser.element(:xpath => "//a[contains( text(), 'Integrations')]")
+# browser.element(:xpath => "//a[contains( text(), 'Help')]")
+# browser.element(:xpath => "//div[contains( text(), 'Account')]")
+
+# #account dropdown items
+# browser.element(:xpath => "//div[contains( text(), 'Account Settings')]")
+# browser.element(:xpath => "//div[contains( text(), 'Billing')]")
+# browser.element(:xpath => "//div[contains( text(), 'Calendar Connections')]")
+# browser.element(:xpath => "//div[contains( text(), 'Admin Management')]")
+# browser.element(:xpath => "//div[contains( text(), 'Organization Settings')]")
+# browser.element(:xpath => "//div[contains( text(), 'Share Your Link')]")
+# browser.element(:xpath => "//div[contains( text(), 'Apps')]")
+# browser.element(:xpath => "//div[contains( text(), 'Logout')]")
+
+
+# # home bar component (top-level)
+# browser.div('data-component':'home-bar')
+# # home bar elements
+# browser.div('data-component':'home-bar').span(text: 'My Calendly')
+# browser.div('data-component':'home-bar').div(text: 'Create')
+
+# browser.div('data-component':'home-bar').div(text: 'Event Types')
+# browser.div('data-component':'home-bar').div(text: 'Scheduled Events')
+# browser.div('data-component':'home-bar').div(text: 'Scheduled Workflows')
+
+
+# #Home content component (top-level)
+# browser.div('data-component':'home-content')
+# #Home content elements
+
+# #Top row
+# browser.div('data-component':'home-content').text_field(placeholder: 'Filter')
+# browser.div('data-component':'home-content').span(class: 'icon-delete')
+
+# browser.div('data-component':'home-content').div(text: 'K')
+# browser.div('data-component':'home-content').div(text: "#{org_owner}")
+
+# browser.div('data-component':'home-content').a(text: 'bravo-qa.calendly.com/keltest')
+# browser.div('data-component':'home-content').div(text: 'New Event Type')
+
+# browser.div('data-component':'home-content').element(:xpath => "//div[contains( text(), 'New Event Type')]")
+# browser.div('data-component':'home-content').button('aria-label': 'Landing page share options')
+
+
+# #Personal Event Types section
+# browser.div('data-component':'home-content').input(name: 'selection')
+
+# #15 minute event type elements
+# browser.div('data-component':'home-content').div(class: 'is-left', :index => 0)
+# browser.div('data-component':'home-content').button('aria-label': '15 Minute Meeting settings')
+# browser.div('data-component':'home-content').h2(text: '15 Minute Meeting')
+# browser.div('data-component':'home-content').a(text: 'View booking page', :index => 0 )
+# browser.div('data-component':'home-content').button(text: 'Copy link', :index => 0 )
+# browser.div('data-component':'home-content').div(text: 'Share', :index => 0 )
+
+# #30 minute event type elements
+# browser.div('data-component':'home-content').div(class: 'is-left', :index => 1)
+# browser.div('data-component':'home-content').button('aria-label': '30 Minute Meeting settings')
+# browser.div('data-component':'home-content').h2(text: '30 Minute Meeting')
+# browser.div('data-component':'home-content').a(text: 'View booking page', :index => 1 )
+# browser.div('data-component':'home-content').button(text: 'Copy link', :index => 1 )
+# browser.div('data-component':'home-content').div(text: 'Share', :index => 1 )
+
+# #60 minute event type elements
+# browser.div('data-component':'home-content').div(class: 'is-left', :index => 2)
+# browser.div('data-component':'home-content').button('aria-label': '60 Minute Meeting settings')
+# browser.div('data-component':'home-content').h2(text: '60 Minute Meeting')
+# browser.div('data-component':'home-content').a(text: 'View booking page', :index => 2 )
+# browser.div('data-component':'home-content').button(text: 'Copy link', :index => 2 )
+# browser.div('data-component':'home-content').div(text: 'Share', :index => 2 )
+
+# #Shared Event Types section
+# browser.div('data-component':'home-content').span(text: 'Shared event types')
+# browser.div('data-component':'home-content').h3(text: "You don't have any shared event types yet.")

--- a/tests/test_landing_page.rb
+++ b/tests/test_landing_page.rb
@@ -1,12 +1,14 @@
-# require 'pry'
-# require 'watir'
+require 'pry'
+require 'watir'
 
-# browser = Watir::Browser.new :chrome
-# browser.goto ''
-# binding.pry
+browser = Watir::Browser.new :chrome
+browser.goto 'bravo-qa.calendly.com'
+binding.pry
 
-# browser.text_field(name: 'email', :index => 1 ).set 'kel.okekpe+watir11@calendly.com'
-# browser.button(type: 'submit', :index => 1).click
+browser.text_field(name: 'email', :index => 1 ).set 'kel.okekpe+watir111@calendly.com'
+
+browser.button(type: 'submit', :index => 1).click
+binding.pry
 # browser.p(:index => 0).text
 # browser.button(value: 'Click here').click
 # binding.pry


### PR DESCRIPTION
Created Page Object file for Calendly Home Page (the page you see after you login)

Followed best practice guidelines for selecting elements:
- To reduce likelihood of duplicate selectors, use `data-component` when possible - this scopes text that may be repeated to a single component or section of the application 
 - example: `browser.div('data-component':'home-bar').div(text: 'some text')`
- Select text by xpath whenever `data-component` not available

